### PR TITLE
Parsing result into correct data type to display to the screen

### DIFF
--- a/RestaurantsNearMe.xcodeproj/project.pbxproj
+++ b/RestaurantsNearMe.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		39B91F862B5C67A100C5FAE5 /* StaticString_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B91F852B5C67A100C5FAE5 /* StaticString_Extensions.swift */; };
 		39B91F882B5CC07C00C5FAE5 /* RestaurantListProving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B91F872B5CC07C00C5FAE5 /* RestaurantListProving.swift */; };
 		39B91F8A2B5CC10C00C5FAE5 /* RestaurantListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B91F892B5CC10C00C5FAE5 /* RestaurantListProvider.swift */; };
+		39B91F8C2B5ECAD800C5FAE5 /* YelpRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B91F8B2B5ECAD800C5FAE5 /* YelpRequestError.swift */; };
+		39B91F8E2B5ED0D400C5FAE5 /* YelpResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B91F8D2B5ED0D400C5FAE5 /* YelpResult.swift */; };
+		39B91F902B5EDDD700C5FAE5 /* HTTPClientError_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B91F8F2B5EDDD700C5FAE5 /* HTTPClientError_Extensions.swift */; };
 		39C3F6942B4F375900D388DA /* Restaurant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C3F6932B4F375900D388DA /* Restaurant.swift */; };
 		39EA1C012B40DAAF00F3B0DC /* LocationProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EA1C002B40DAAF00F3B0DC /* LocationProviding.swift */; };
 		39EA1C032B40DB4900F3B0DC /* LocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EA1C022B40DB4900F3B0DC /* LocationProvider.swift */; };
@@ -62,6 +65,9 @@
 		39B91F852B5C67A100C5FAE5 /* StaticString_Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticString_Extensions.swift; sourceTree = "<group>"; };
 		39B91F872B5CC07C00C5FAE5 /* RestaurantListProving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantListProving.swift; sourceTree = "<group>"; };
 		39B91F892B5CC10C00C5FAE5 /* RestaurantListProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantListProvider.swift; sourceTree = "<group>"; };
+		39B91F8B2B5ECAD800C5FAE5 /* YelpRequestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelpRequestError.swift; sourceTree = "<group>"; };
+		39B91F8D2B5ED0D400C5FAE5 /* YelpResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelpResult.swift; sourceTree = "<group>"; };
+		39B91F8F2B5EDDD700C5FAE5 /* HTTPClientError_Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientError_Extensions.swift; sourceTree = "<group>"; };
 		39C3F6932B4F375900D388DA /* Restaurant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Restaurant.swift; sourceTree = "<group>"; };
 		39EA1C002B40DAAF00F3B0DC /* LocationProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProviding.swift; sourceTree = "<group>"; };
 		39EA1C022B40DB4900F3B0DC /* LocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationProvider.swift; sourceTree = "<group>"; };
@@ -194,6 +200,8 @@
 				39B91F892B5CC10C00C5FAE5 /* RestaurantListProvider.swift */,
 				39EA1C192B43B6D700F3B0DC /* YelpRequest.swift */,
 				3907872D2B4F3CAA0075AA24 /* YelpRequestProvider.swift */,
+				39B91F8B2B5ECAD800C5FAE5 /* YelpRequestError.swift */,
+				39B91F8D2B5ED0D400C5FAE5 /* YelpResult.swift */,
 			);
 			path = YelpRequest;
 			sourceTree = "<group>";
@@ -215,6 +223,7 @@
 				39EA1C0B2B42004800F3B0DC /* Color_Extensions.swift */,
 				39EA1C0F2B42039D00F3B0DC /* DeferredLoadingFullAnimationModifier.swift */,
 				39B91F852B5C67A100C5FAE5 /* StaticString_Extensions.swift */,
+				39B91F8F2B5EDDD700C5FAE5 /* HTTPClientError_Extensions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -346,6 +355,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39B91F902B5EDDD700C5FAE5 /* HTTPClientError_Extensions.swift in Sources */,
 				39B91F862B5C67A100C5FAE5 /* StaticString_Extensions.swift in Sources */,
 				39C3F6942B4F375900D388DA /* Restaurant.swift in Sources */,
 				39B91F842B5C65BA00C5FAE5 /* URL_Extensions.swift in Sources */,
@@ -363,6 +373,7 @@
 				394D6E812B2961DB0041B56E /* CloudKitServiceActor.swift in Sources */,
 				39477BEA2B14FF4600D9895B /* APIKey.swift in Sources */,
 				39B91F8A2B5CC10C00C5FAE5 /* RestaurantListProvider.swift in Sources */,
+				39B91F8E2B5ED0D400C5FAE5 /* YelpResult.swift in Sources */,
 				39EA1C012B40DAAF00F3B0DC /* LocationProviding.swift in Sources */,
 				39477BD42B1191A200D9895B /* SplashScreenViewModel.swift in Sources */,
 				39477BEC2B150EC000D9895B /* CloudKitService.swift in Sources */,
@@ -372,6 +383,7 @@
 				39477BD02B114A4500D9895B /* LoadingView.swift in Sources */,
 				39477BF02B1542F000D9895B /* CloudKitServiceError.swift in Sources */,
 				39477BDD2B12A1E300D9895B /* Toast.swift in Sources */,
+				39B91F8C2B5ECAD800C5FAE5 /* YelpRequestError.swift in Sources */,
 				39EA1C032B40DB4900F3B0DC /* LocationProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RestaurantsNearMe/Data/Interfaces/RestaurantListProving.swift
+++ b/RestaurantsNearMe/Data/Interfaces/RestaurantListProving.swift
@@ -10,7 +10,8 @@ import Combine
 
 // sourcery: AutoMockable
 protocol RestaurantListProving {
-  var restaurants: PassthroughSubject<[Restaurant], Never> { get }
-  
+  var restaurants: AnyPublisher<[Restaurant], Never> { get }
+  var fetchingError: AnyPublisher<String, Never> { get }
+
   func updateRestaurants() async
 }

--- a/RestaurantsNearMe/Data/Interfaces/RestaurantListProving.swift
+++ b/RestaurantsNearMe/Data/Interfaces/RestaurantListProving.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 // sourcery: AutoMockable
-protocol RestaurantListProving {
+protocol RestaurantListProviding {
   var restaurants: AnyPublisher<[Restaurant], Never> { get }
   var fetchingError: AnyPublisher<String, Never> { get }
 

--- a/RestaurantsNearMe/Data/YelpRequest/Restaurant.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/Restaurant.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// TODO: - This is a stub that will be fleshed out when actual decoding occurs
-struct Restaurant: Decodable {
+struct Restaurant: Decodable, Identifiable {
+  let id: String
   let name: String
 }

--- a/RestaurantsNearMe/Data/YelpRequest/Restaurant.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/Restaurant.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// TODO: - This is a stub that will be fleshed out when actual decoding occurs
+// TODO: - This is a stub that will be fleshed out when actual decoding and displaying occurs
 struct Restaurant: Decodable, Identifiable {
   let id: String
   let name: String

--- a/RestaurantsNearMe/Data/YelpRequest/RestaurantListProvider.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/RestaurantListProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 import Networking
 import Combine
 
-struct RestaurantListProvider: RestaurantListProving {
+struct RestaurantListProvider: RestaurantListProviding {
   private let _restaurants = PassthroughSubject<[Restaurant], Never>()
   private let _errorMessage = PassthroughSubject<String, Never>()
 

--- a/RestaurantsNearMe/Data/YelpRequest/YelpRequestError.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/YelpRequestError.swift
@@ -1,0 +1,21 @@
+//
+//  YelpRequestError.swift
+//  RestaurantsNearMe
+//
+//  Created by Colin Evans on 2024-01-22.
+//
+
+import Foundation
+
+enum YelpRequestError: Error {
+  case unableToParseRestaurants
+}
+
+extension YelpRequestError: CustomStringConvertible {
+  var description: String {
+    switch self {
+    case .unableToParseRestaurants:
+      return "Unable to retrieve results. Please ensure the location is available and try again."
+    }
+  }
+}

--- a/RestaurantsNearMe/Data/YelpRequest/YelpRequestProvider.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/YelpRequestProvider.swift
@@ -27,7 +27,17 @@ class YelpRequestProvider {
         let request = YelpRequest(
           path: baseURLPath,
           headers: authHeader,
-          parameters: locationParameters
+          parameters: locationParameters,
+          resource: Resource<[Restaurant]>(
+            parse: {
+              do {
+                let decodedData = try JSONDecoder().decode(YelpResult.self, from: $0)
+                return decodedData.businesses
+              } catch {
+                throw YelpRequestError.unableToParseRestaurants
+              }
+            }
+          )
         )
         self.activeRequest.send(request)
       }.store(in: &cancellables)

--- a/RestaurantsNearMe/Data/YelpRequest/YelpResult.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/YelpResult.swift
@@ -21,24 +21,20 @@ struct YelpResult: Decodable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     businesses = try container.decode([Restaurant].self, forKey: .businesses)
     total = (try? container.decodeIfPresent(Int.self, forKey: .total)) ?? 0
-    let location = try container.decode(Location.self, forKey: .region)
-    region = CLLocation(latitude: location.latitude, longitude: location.longitude)
-  }
-}
-
-private struct Location: Decodable {
-  let longitude: Double
-  let latitude: Double
-  
-  enum CodingKeys: CodingKey {
-    case center
+    let value = try container.decode(Region.self, forKey: .region)
+    region = CLLocation(
+      latitude: value.center.latitude,
+      longitude: value.center.longitude
+    )
   }
   
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    let values = try container.decodeIfPresent(Location.self, forKey: .center)
+  // MARK: - Private Struct for Decoding
+  private struct Region: Decodable {
+    let center: Location
     
-    latitude = values?.latitude ?? 0
-    longitude = values?.longitude ?? 0
+    struct Location: Decodable {
+      let longitude: Double
+      let latitude: Double
+    }
   }
 }

--- a/RestaurantsNearMe/Data/YelpRequest/YelpResult.swift
+++ b/RestaurantsNearMe/Data/YelpRequest/YelpResult.swift
@@ -1,0 +1,44 @@
+//
+//  YelpResult.swift
+//  RestaurantsNearMe
+//
+//  Created by Colin Evans on 2024-01-22.
+//
+
+import Foundation
+import CoreLocation
+
+struct YelpResult: Decodable {
+  let businesses: [Restaurant]
+  let total: Int
+  let region: CLLocation
+  
+  enum CodingKeys: String, CodingKey {
+    case businesses, total, region
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    businesses = try container.decode([Restaurant].self, forKey: .businesses)
+    total = (try? container.decodeIfPresent(Int.self, forKey: .total)) ?? 0
+    let location = try container.decode(Location.self, forKey: .region)
+    region = CLLocation(latitude: location.latitude, longitude: location.longitude)
+  }
+}
+
+private struct Location: Decodable {
+  let longitude: Double
+  let latitude: Double
+  
+  enum CodingKeys: CodingKey {
+    case center
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let values = try container.decodeIfPresent(Location.self, forKey: .center)
+    
+    latitude = values?.latitude ?? 0
+    longitude = values?.longitude ?? 0
+  }
+}

--- a/RestaurantsNearMe/Mocks/AutoGeneratedMocks.swift
+++ b/RestaurantsNearMe/Mocks/AutoGeneratedMocks.swift
@@ -128,11 +128,16 @@ class LocationProvidingMock: LocationProviding {
 class RestaurantListProvingMock: RestaurantListProving {
 
 
-    var restaurants: PassthroughSubject<[Restaurant], Never> {
+    var restaurants: AnyPublisher<[Restaurant], Never> {
         get { return underlyingRestaurants }
         set(value) { underlyingRestaurants = value }
     }
-    var underlyingRestaurants: (PassthroughSubject<[Restaurant], Never>)!
+    var underlyingRestaurants: (AnyPublisher<[Restaurant], Never>)!
+    var fetchingError: AnyPublisher<String, Never> {
+        get { return underlyingFetchingError }
+        set(value) { underlyingFetchingError = value }
+    }
+    var underlyingFetchingError: (AnyPublisher<String, Never>)!
 
 
     //MARK: - updateRestaurants

--- a/RestaurantsNearMe/Mocks/AutoGeneratedMocks.swift
+++ b/RestaurantsNearMe/Mocks/AutoGeneratedMocks.swift
@@ -125,7 +125,7 @@ class LocationProvidingMock: LocationProviding {
     }
 
 }
-class RestaurantListProvingMock: RestaurantListProving {
+class RestaurantListProvidingMock: RestaurantListProviding {
 
 
     var restaurants: AnyPublisher<[Restaurant], Never> {

--- a/RestaurantsNearMe/Presentation/RestaurantListViewModel/RestaurantListViewModel.swift
+++ b/RestaurantsNearMe/Presentation/RestaurantListViewModel/RestaurantListViewModel.swift
@@ -14,6 +14,7 @@ class RestaurantListViewModel: ObservableObject {
   @Published var showLocationRedirect = false
   @Published var areLocationPermissionsValid = false
   @Published var restaurants = [Restaurant]()
+  @Published var requestError: String?
   
   private let locationProvider: any LocationProviding
   private let restaurantsListProvider: any RestaurantListProving
@@ -36,9 +37,14 @@ class RestaurantListViewModel: ObservableObject {
       .receive(on: DispatchQueue.main)
       .map { $0 != nil }
       .assign(to: &$showLocationRedirect)
+
     restaurantsListProvider.restaurants
       .receive(on: DispatchQueue.main)
       .assign(to: &$restaurants)
+    restaurantsListProvider.fetchingError
+      .compactMap({ $0 })
+      .receive(on: DispatchQueue.main)
+      .assign(to: &$requestError)
   }
   
   func askLocationPermissionsIfNeeded() {

--- a/RestaurantsNearMe/Presentation/RestaurantListViewModel/RestaurantListViewModel.swift
+++ b/RestaurantsNearMe/Presentation/RestaurantListViewModel/RestaurantListViewModel.swift
@@ -17,11 +17,11 @@ class RestaurantListViewModel: ObservableObject {
   @Published var requestError: String?
   
   private let locationProvider: any LocationProviding
-  private let restaurantsListProvider: any RestaurantListProving
+  private let restaurantsListProvider: any RestaurantListProviding
   
   init(
     locationProvider: some LocationProviding,
-    restaurantsListProvider: some RestaurantListProving
+    restaurantsListProvider: some RestaurantListProviding
   ) {
     self.locationProvider = locationProvider
     self.restaurantsListProvider = restaurantsListProvider
@@ -70,7 +70,7 @@ extension RestaurantListViewModel {
   static func preview() -> RestaurantListViewModel {
     RestaurantListViewModel(
       locationProvider: LocationProvidingMock(),
-      restaurantsListProvider: RestaurantListProvingMock()
+      restaurantsListProvider: RestaurantListProvidingMock()
     )
   }
 }

--- a/RestaurantsNearMe/Presentation/Utilities/HTTPClientError_Extensions.swift
+++ b/RestaurantsNearMe/Presentation/Utilities/HTTPClientError_Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  HTTPClientError_Extensions.swift
+//  RestaurantsNearMe
+//
+//  Created by Colin Evans on 2024-01-22.
+//
+
+import Foundation
+import Networking
+
+extension HTTPClientError: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .invalidResponse:
+      return "Invalid Server Response, please try again later"
+    }
+  }
+}


### PR DESCRIPTION
Summary:

The previous ticket sets up the infrastructure to make the API call to `yelp.com/reference/v3_business_search` but did not parse the results into the correct type to display on screen.

This ticket `maps` the Data output from the API call to a list of `[Restaurant]` that can be displayed on screen.

The API itself has a top level dictionary with 3 values:
```
{
  "businesses": { a list of n results decoded into [Restaurant] }
  "total": Int 
  "region": {
     "center": {
        "longitude": Double
        "latitude": Double   
      }
  }
}
```

